### PR TITLE
prevent duplicate cities

### DIFF
--- a/src/stores/Cities.js
+++ b/src/stores/Cities.js
@@ -5,7 +5,11 @@ function createCitiesStore() {
 
   return {
     subscribe,
-    addCity: (city) => update((cities) => [...cities, city]),
+    addCity: (city) => update((cities) => {
+      const exists = cities.find(c => c.city === city.city);
+      if (!exists) return [...cities, city];
+      return cities;
+    }),
     deleteCity: (cityToRemove) =>
       update((cities) =>
         cities.filter((city) => {

--- a/src/stores/Cities.js
+++ b/src/stores/Cities.js
@@ -5,11 +5,12 @@ function createCitiesStore() {
 
   return {
     subscribe,
-    addCity: (city) => update((cities) => {
-      const exists = cities.find(c => c.city === city.city);
-      if (!exists) return [...cities, city];
-      return cities;
-    }),
+    addCity: (city) =>
+      update((cities) => {
+        const exists = cities.find((c) => c.city === city.city);
+        if (!exists) return [...cities, city];
+        return cities;
+      }),
     deleteCity: (cityToRemove) =>
       update((cities) =>
         cities.filter((city) => {

--- a/tests/Cities.test.js
+++ b/tests/Cities.test.js
@@ -110,12 +110,8 @@ describe("[UNIT] Cities Store", () => {
     });
 
     cities.addCity(newCity);
-    cities.addCity(newCity);
-    cities.addCity(newCity);
-    cities.addCity(newCity);
-    cities.addCity(newCity);
 
-    expect(c.length).toBe(5);
+    expect(c.length).toBe(1);
 
     cities.reset();
 


### PR DESCRIPTION
Hello,

I've made a change to prevent duplicate cities from being added (fixes #55)

I also had to modify one of the tests as it was attempting to add multiple of the same city.

Hopefully that's what you wanted - let me know if there's any issues and I'll take another look - thanks!