### PR TITLE
fix: fetch data in the order it was stored

### DIFF
--- a/src/GetWeather.js
+++ b/src/GetWeather.js
@@ -1,14 +1,12 @@
-export default function getWeather(newCityName, newCountryName) {
-  let apiKey = process.env.WEATHER_API_KEY || "WEATHER_API_KEY";
-  let weather = fetch(
+export default async function getWeather(newCityName, newCountryName) {
+  const apiKey =
+    process.env.WEATHER_API_KEY || "8f02459098604a039aac044d57d0a727";
+  const response = await fetch(
     `https://api.weatherbit.io/v2.0/forecast/daily?city=${newCityName}&country=${newCountryName}&key=${apiKey}`
-  ).then((response) => {
-    if (response.status === 200) {
-      return response.json();
-    }
-
+  );
+  if (response.status !== 200) {
     return Promise.reject(response.status);
-  });
-
+  }
+  const weather = await response.json();
   return weather;
 }

--- a/src/GetWeather.js
+++ b/src/GetWeather.js
@@ -1,6 +1,6 @@
 export default async function getWeather(newCityName, newCountryName) {
   const apiKey =
-    process.env.WEATHER_API_KEY || "8f02459098604a039aac044d57d0a727";
+    process.env.WEATHER_API_KEY || "WEATHER_API_KEY";
   const response = await fetch(
     `https://api.weatherbit.io/v2.0/forecast/daily?city=${newCityName}&country=${newCountryName}&key=${apiKey}`
   );

--- a/src/GetWeather.js
+++ b/src/GetWeather.js
@@ -1,6 +1,5 @@
 export default async function getWeather(newCityName, newCountryName) {
-  const apiKey =
-    process.env.WEATHER_API_KEY || "WEATHER_API_KEY";
+  const apiKey = process.env.WEATHER_API_KEY || "WEATHER_API_KEY";
   const response = await fetch(
     `https://api.weatherbit.io/v2.0/forecast/daily?city=${newCityName}&country=${newCountryName}&key=${apiKey}`
   );

--- a/src/components/InputFields.svelte
+++ b/src/components/InputFields.svelte
@@ -9,10 +9,11 @@
   function handleClick() {
     getWeather(newCityName, newCountryName)
       .then((weather) => {
-        let newCity = new City(newCityName, newCountryName, weather.data);
+        const newCity = new City(newCityName, newCountryName, weather.data);
+        const savedCities = localStorage.getItem("cities");
         localStorage.setItem(
           "cities",
-          localStorage.getItem("cities") + `;${newCityName},${newCountryName}`
+          `${savedCities && `${savedCities};`}${newCityName},${newCountryName}`
         );
         cities.addCity(newCity);
         clearInputBoxes();

--- a/src/components/InstructionBlock.svelte
+++ b/src/components/InstructionBlock.svelte
@@ -1,4 +1,5 @@
 <script>
+
 </script>
 
 <div class="fade-in-out">

--- a/src/components/InstructionBlock.svelte
+++ b/src/components/InstructionBlock.svelte
@@ -1,5 +1,4 @@
 <script>
-
 </script>
 
 <div class="fade-in-out">

--- a/src/components/WeatherTable.svelte
+++ b/src/components/WeatherTable.svelte
@@ -15,24 +15,18 @@
         }).join(";"))
   }
 
-  onMount(() => {
+  onMount(async () => {
       let savedCitiesAndCountries = localStorage.getItem("cities");
-      if (savedCitiesAndCountries !== "" && savedCitiesAndCountries !== null)
+      if (savedCitiesAndCountries)
       {
-          let savedCitiesAndCountries = localStorage.getItem("cities").split(";");
-
+          savedCitiesAndCountries = savedCitiesAndCountries.split(";");
           for (let i = 0; i < savedCitiesAndCountries.length; i++) {
-              let cityAndCountry = savedCitiesAndCountries[i].split(",");
-              let city = cityAndCountry[0];
-              let country = cityAndCountry[1];
-              getWeather(city, country)
-                      .then((weather) => {
-                          cities.addCity(new City(city, country, weather.data))
-                      })
-                        .catch(() => {
-
-                        });
-
+              const cityAndCountry = savedCitiesAndCountries[i].split(",");
+              const [city, country] = cityAndCountry;
+              try {
+                const weather = await getWeather(city, country);
+                cities.addCity(new City(city, country, weather.data));
+              } catch (e) {}
           }
       }
   })

--- a/src/components/WeatherTable.svelte
+++ b/src/components/WeatherTable.svelte
@@ -26,7 +26,7 @@
               try {
                 const weather = await getWeather(city, country);
                 cities.addCity(new City(city, country, weather.data));
-              } catch (e) {}
+              } catch(e) { return; }
           }
       }
   })


### PR DESCRIPTION
Hey again!

## Changes
- general cleanup (favouring const over let where appropriate, removing redundant code etc)
- now correctly appends rather than prepends semicolon when saving item to localstorage (this was causing a malformed request to be fired off on page load due to the way the string is being parsed)
- switched to async/await for fetching weather data on page load so that the original order is retained on subsequent visits (fixes #54)