### PR TITLE
Added few more E2E test for weather search valid cases

### DIFF
--- a/cypress/fixtures/cityCountry.json
+++ b/cypress/fixtures/cityCountry.json
@@ -1,4 +1,10 @@
 {
-  "city": "Tokyo",
-  "country": "Japan"
+  "1": {
+    "city": "Tokyo",
+    "country": "Japan"
+  },
+  "2": {
+    "city": "Winnipeg",
+    "country": "Canada"
+  }
 }

--- a/cypress/integration/examples/searchCity.spec.js
+++ b/cypress/integration/examples/searchCity.spec.js
@@ -9,14 +9,25 @@ context('Weather', () => {
 
     describe('User can search for weather in a city', () => {
         it('should be possible to search the weather of a single city at a time', () => {
-            cy.get('#cityInput').type(cityCountry.city)
-            cy.get('input[placeholder="Country"]').type(cityCountry.country)
-            cy.get('#cityInput ~ button').click()
+            cy.searchForCity(cityCountry['1'].city,cityCountry['1'].country)
             cy.get('.city-name-cell').should('be.visible')
                 .then(($city) => {
                     const text = $city.text()
-                    expect(text).to.include(cityCountry.city)
+                    expect(text).to.include(cityCountry['1'].city)
                 })
+        })
+
+        it('should not add new row in table while searching for the city that was searched earlier', () => {
+            //Note that the city we searched in above test is in the table already and we are searching again for the same city
+            cy.searchForCity(cityCountry['1'].city,cityCountry['1'].country)
+            cy.waitForAnimationToFinish()
+            cy.assertTableRowNumbers(1)
+        })
+
+        it('should add new row in the table when a new city is searched', () => {
+            cy.searchForCity(cityCountry['2'].city,cityCountry['2'].country)
+            cy.waitForAnimationToFinish()
+            cy.assertTableRowNumbers(2)
         })
     })
 })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,0 +1,16 @@
+Cypress.Commands.add('waitForAnimationToFinish', () => {
+    cy.wait(3000)
+})
+
+Cypress.Commands.add('searchForCity', (city, country) => {
+    cy.get('#cityInput').type(city)
+    cy.get('input[placeholder="Country"]').type(country)
+    cy.get('#cityInput ~ button').click()
+})
+
+Cypress.Commands.add('assertTableRowNumbers', (expectedNumber) => {
+    cy.get('table')
+        .find('tr')
+        .its('length')
+        .should('eq',expectedNumber)
+})


### PR DESCRIPTION
Hey again,
I have added a few more scenarios to the e2e test.
:heavy_check_mark: should not add new row in table while searching for the city that was searched earlier
:heavy_check_mark: should add new row in the table when a new city is searched

### Related issues
part of https://github.com/bartius-nigel/weather-comparitor/issues/13

### How this has been tested?
- By running the tests locally